### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ kubectl apply -f https://raw.githubusercontent.com/eduk8s-labs/lab-octant-testin
 Then run:
 
 ```
-kubectl get trainingportal/lab-octant-testing
+kubectl get trainingportal/lab-getting-started-with-octant
 ```
 
 This will output the URL to access the web portal for the training environment.


### PR DESCRIPTION
This appears to be an error as in the referenced yml the training portal name is "lab-getting-started-with-octant", not "lab-octant-testing". I have updated the command in the reflect this name, as needed to get the command to work properly. 

Thanks!